### PR TITLE
enhancement: added meta field as per mcp specification for tool call metadata

### DIFF
--- a/src/echo/tools/mcp_connection_manager.py
+++ b/src/echo/tools/mcp_connection_manager.py
@@ -147,7 +147,7 @@ class MCPConnectionManager:
         async with self._locks[self._server_id]:
             self._tools_cache.pop(self._server_id, None)
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], meta: Optional[Dict[str, Any]]=None) -> Any:
         """
         Execute tool with simple one-retry logic.
 
@@ -168,7 +168,7 @@ class MCPConnectionManager:
 
         try:
             # Try once with current connection
-            result = await conn.session.call_tool(tool_name, arguments=arguments)
+            result = await conn.session.call_tool(tool_name, arguments=arguments, meta=meta)
             conn.last_used = time.time()
             logger.debug(f"Successfully executed tool: {tool_name}")
             return result

--- a/src/echo/tools/mcp_tool.py
+++ b/src/echo/tools/mcp_tool.py
@@ -73,8 +73,9 @@ class MCPTool(BaseTool):
         """
         try:
             # TODO: if you need any params from tool context, figure it out here
+            meta = kwargs.pop("meta", {})
             result = await self._manager.execute_tool(
-                tool_name=self.name, arguments=kwargs
+                tool_name=self.name, arguments=kwargs, meta=meta
             )
 
             structured_content = (

--- a/src/echo/tools/schemas.py
+++ b/src/echo/tools/schemas.py
@@ -61,6 +61,9 @@ class ElicitationDetails(BaseModel):
     input: Dict[str, Any]
     meta: Optional[Dict[str, Any]] = Field(default=None, alias="_meta")
     status: Optional[ElicitationStatus] = None
+    hidden_message: Optional[str] = None
+    disp_toast_msg: Optional[str] = None
+    mcp_meta_fields: Optional[list[str]] = None
 
 
 class ElicitationResponse(BaseModel):

--- a/src/echo/tools/schemas.py
+++ b/src/echo/tools/schemas.py
@@ -61,9 +61,6 @@ class ElicitationDetails(BaseModel):
     input: Dict[str, Any]
     meta: Optional[Dict[str, Any]] = Field(default=None, alias="_meta")
     status: Optional[ElicitationStatus] = None
-    hidden_message: Optional[str] = None
-    disp_toast_msg: Optional[str] = None
-    mcp_meta_fields: Optional[list[str]] = None
 
 
 class ElicitationResponse(BaseModel):


### PR DESCRIPTION
_meta field is as per mcp specification. Used to get extra context in tool call without altering tool input definition. It is extracted from SessionContext object at runtime.