### PR TITLE
feat: on-prem providers — Sarvam STT, OpenAI-compatible LLM, file pro…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ gemini = ["google-genai>=1.0.0"]
 
 # Audio Transcription Providers
 ekacare = ["httpx>=0.27.0"]
-sarvam = ["httpx>=0.27.0"]
+sarvam = ["sarvamai>=0.1.20"]
 
 # Framework Integrations
 crewai = ["crewai>=1.6.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "echo"
-version = "0.3.6"
+version = "0.4.0"
 description = "Framework-agnostic medical Agent building SDK with multi-provider LLM and Tools and Skills support"
 readme = "README.md"
 license = "MIT"
@@ -37,6 +37,7 @@ gemini = ["google-genai>=1.0.0"]
 
 # Audio Transcription Providers
 ekacare = ["httpx>=0.27.0"]
+sarvam = ["httpx>=0.27.0"]
 
 # Framework Integrations
 crewai = ["crewai>=1.6.1"]

--- a/src/echo/__init__.py
+++ b/src/echo/__init__.py
@@ -24,3 +24,15 @@ __all__ = [
     "llm",
     "tools",
 ]
+
+# --- Backwards-compatible aliases (pre-0.3.7 names) --------------------------
+# AgentConfig/PersonaConfig/TaskConfig were renamed to AgentPrompt/
+# PromptPersona/PromptTask. Keep the old names importable so consumers pinned
+# to the 0.3.x API (e.g. voice2rx-based backends) upgrade without changes.
+from .prompts.schemas import (  # noqa: E402
+    AgentPrompt as AgentConfig,
+    PromptPersona as PersonaConfig,
+    PromptTask as TaskConfig,
+)
+
+__all__ += ["AgentConfig", "PersonaConfig", "TaskConfig"]

--- a/src/echo/audio/transcription/config.py
+++ b/src/echo/audio/transcription/config.py
@@ -17,7 +17,7 @@ EKACARE_LANGUAGES = ["en-IN", "en-US", "hi"]
 
 
 class TranscriberConfig(BaseModel):
-    provider: Literal["gemini", "ekacare"] = Field(
+    provider: Literal["gemini", "ekacare", "sarvam"] = Field(
         default_factory=lambda: os.getenv("ECHO_DEFAULT_TRANSCRIBER_PROVIDER", "gemini")
     )
     model: str = Field(
@@ -26,6 +26,7 @@ class TranscriberConfig(BaseModel):
         )
     )
     api_key: Optional[str] = None
+    base_url: Optional[str] = None  # provider endpoint override (proxies, self-hosted)
     language: Optional[str] = None
     temperature: float = 0.0
     max_output_tokens: int = 8192
@@ -33,6 +34,9 @@ class TranscriberConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_model(self):
+        if self.provider == "sarvam" and self.model.startswith("models/gemini"):
+            # the env default model is gemini-shaped; swap in sarvam's default
+            self.model = os.getenv("SARVAM_STT_MODEL", "saarika:v2.5")
         if self.provider == "gemini" and self.model not in GEMINI_AUDIO_MODELS:
             raise ValueError(
                 f"Model {self.model!r} not supported for provider 'gemini'. "

--- a/src/echo/audio/transcription/factory.py
+++ b/src/echo/audio/transcription/factory.py
@@ -58,7 +58,18 @@ def get_transcriber(config: TranscriberConfig) -> BaseTranscriber:
                 "Install with: pip install 'echo-sdk[ekacare]'"
             ) from e
 
+    if provider == "sarvam":
+        try:
+            from .sarvam import SarvamTranscriber
+
+            return SarvamTranscriber(config)
+        except ImportError as e:
+            raise ImportError(
+                "httpx is required for Sarvam transcription. "
+                "Install with: pip install 'echo-sdk[sarvam]'"
+            ) from e
+
     raise ValueError(
         f"Unsupported transcription provider: {provider!r}. "
-        f"Supported: gemini, ekacare"
+        f"Supported: gemini, ekacare, sarvam"
     )

--- a/src/echo/audio/transcription/factory.py
+++ b/src/echo/audio/transcription/factory.py
@@ -65,7 +65,7 @@ def get_transcriber(config: TranscriberConfig) -> BaseTranscriber:
             return SarvamTranscriber(config)
         except ImportError as e:
             raise ImportError(
-                "httpx is required for Sarvam transcription. "
+                "sarvamai is required for Sarvam transcription. "
                 "Install with: pip install 'echo-sdk[sarvam]'"
             ) from e
 

--- a/src/echo/audio/transcription/sarvam.py
+++ b/src/echo/audio/transcription/sarvam.py
@@ -92,6 +92,27 @@ class SarvamTranscriber(BaseTranscriber):
             return "unknown"  # Sarvam auto-detects
         return _LANGUAGE_MAP.get(lang.lower(), lang)
 
+    @staticmethod
+    async def _load_audio(audio: AudioInput) -> bytes:
+        """Materialize the AudioInput contract (bytes | file path | http(s) URL)
+        into bytes.
+
+        The sarvamai SDK only accepts file bytes/handles — it does not fetch
+        remote URLs — so URL inputs are downloaded here first. httpx is used
+        because it is already a dependency of sarvamai itself.
+        """
+        if isinstance(audio, bytes):
+            return audio
+        if audio.startswith(("http://", "https://")):
+            import httpx
+
+            async with httpx.AsyncClient(timeout=60.0) as http:
+                resp = await http.get(audio)
+                resp.raise_for_status()
+                return resp.content
+        with open(audio, "rb") as f:
+            return f.read()
+
     async def transcribe(
         self,
         audio: AudioInput,
@@ -100,19 +121,7 @@ class SarvamTranscriber(BaseTranscriber):
         **kwargs: Any,
     ) -> TranscriptionResponse:
         try:
-            if isinstance(audio, str):
-                if audio.startswith(("http://", "https://")):
-                    import httpx
-
-                    async with httpx.AsyncClient(timeout=60.0) as http:
-                        resp = await http.get(audio)
-                        resp.raise_for_status()
-                        content = resp.content
-                else:
-                    with open(audio, "rb") as f:
-                        content = f.read()
-            else:
-                content = audio
+            content = await self._load_audio(audio)
 
             mime = (mime_type or "audio/mp4").split(";")[0].strip().lower()
             ext = _EXT_BY_MIME.get(mime, "m4a")

--- a/src/echo/audio/transcription/sarvam.py
+++ b/src/echo/audio/transcription/sarvam.py
@@ -1,8 +1,10 @@
-"""Sarvam AI speech-to-text provider (on-prem default STT — plan decision #14).
+"""Sarvam AI speech-to-text provider, built on the official ``sarvamai`` SDK.
 
-Uses Sarvam's Speech-to-Text API (saarika models) via httpx. Strong Indic
-language coverage. Configure with SARVAM_API_KEY; base URL overridable for
-proxies via config.base_url / SARVAM_BASE_URL.
+Strong Indic language coverage (saarika models). Configure with
+SARVAM_API_KEY; base URL overridable for proxies/self-hosted gateways via
+``TranscriberConfig.base_url`` or SARVAM_BASE_URL.
+
+Install: pip install 'echo-sdk[sarvam]'  (extra pulls ``sarvamai``)
 """
 
 from __future__ import annotations
@@ -11,15 +13,12 @@ import logging
 import os
 from typing import Any, Optional
 
-import httpx
-
 from .base import BaseTranscriber
 from .config import TranscriberConfig
 from .schemas import AudioInput, TranscriptionResponse
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BASE_URL = "https://api.sarvam.ai"
 DEFAULT_MODEL = "saarika:v2.5"
 
 # echo language codes → Sarvam language_code (BCP-47-ish)
@@ -36,6 +35,9 @@ _LANGUAGE_MAP = {
     "pa": "pa-IN",
     "ta": "ta-IN",
     "te": "te-IN",
+    "as": "as-IN",
+    "ur": "ur-IN",
+    "ne": "ne-IN",
 }
 
 _EXT_BY_MIME = {
@@ -46,22 +48,43 @@ _EXT_BY_MIME = {
     "audio/wav": "wav",
     "audio/webm": "webm",
     "audio/ogg": "ogg",
+    "audio/aac": "aac",
+    "audio/flac": "flac",
 }
 
 
 class SarvamTranscriber(BaseTranscriber):
-    """Transcriber backed by Sarvam's /speech-to-text endpoint."""
+    """Transcriber backed by Sarvam's speech-to-text via the official SDK."""
 
     def __init__(self, config: TranscriberConfig):
         super().__init__(config)
         self.api_key = config.api_key or os.getenv("SARVAM_API_KEY")
         self.base_url = (
-            getattr(config, "base_url", None)
-            or os.getenv("SARVAM_BASE_URL")
-            or DEFAULT_BASE_URL
-        ).rstrip("/")
+            getattr(config, "base_url", None) or os.getenv("SARVAM_BASE_URL") or None
+        )
         if not self.api_key:
             raise ValueError("Sarvam requires an API key (SARVAM_API_KEY)")
+        self._client = None
+
+    @property
+    def client(self):
+        """Lazy AsyncSarvamAI, with optional endpoint override."""
+        if self._client is None:
+            from sarvamai import AsyncSarvamAI
+
+            kwargs: dict = {"api_subscription_key": self.api_key}
+            if self.base_url:
+                from sarvamai.environment import SarvamAIEnvironment
+
+                base = self.base_url.rstrip("/")
+                kwargs["environment"] = SarvamAIEnvironment(
+                    base=base,
+                    production=base.replace("https://", "wss://").replace(
+                        "http://", "ws://"
+                    ),
+                )
+            self._client = AsyncSarvamAI(**kwargs)
+        return self._client
 
     def _language_code(self) -> str:
         lang = (self.config.language or "").strip()
@@ -79,8 +102,10 @@ class SarvamTranscriber(BaseTranscriber):
         try:
             if isinstance(audio, str):
                 if audio.startswith(("http://", "https://")):
-                    async with httpx.AsyncClient(timeout=60.0) as client:
-                        resp = await client.get(audio)
+                    import httpx
+
+                    async with httpx.AsyncClient(timeout=60.0) as http:
+                        resp = await http.get(audio)
                         resp.raise_for_status()
                         content = resp.content
                 else:
@@ -89,36 +114,23 @@ class SarvamTranscriber(BaseTranscriber):
             else:
                 content = audio
 
-            mime = mime_type or "audio/mp4"
-            ext = _EXT_BY_MIME.get(mime.split(";")[0].strip().lower(), "m4a")
+            mime = (mime_type or "audio/mp4").split(";")[0].strip().lower()
+            ext = _EXT_BY_MIME.get(mime, "m4a")
 
-            data = {
-                "model": self.model or DEFAULT_MODEL,
-                "language_code": self._language_code(),
-            }
-            files = {"file": (f"audio.{ext}", content, mime)}
-
-            async with httpx.AsyncClient(
-                timeout=self.config.request_timeout_s
-            ) as client:
-                resp = await client.post(
-                    f"{self.base_url}/speech-to-text",
-                    headers={"api-subscription-key": self.api_key},
-                    data=data,
-                    files=files,
-                )
-
-            if resp.status_code != 200:
-                return TranscriptionResponse(
-                    error=f"Sarvam API {resp.status_code}: {resp.text[:500]}"
-                )
-
-            payload = resp.json()
-            return TranscriptionResponse(
-                text=payload.get("transcript", "") or "",
-                language_detected=payload.get("language_code"),
-                details={"request_id": payload.get("request_id")},
+            result = await self.client.speech_to_text.transcribe(
+                file=(f"audio.{ext}", content, mime),
+                model=self.model or DEFAULT_MODEL,
+                language_code=self._language_code(),
             )
-        except Exception as e:  # network, IO
+
+            return TranscriptionResponse(
+                text=result.transcript or "",
+                language_detected=result.language_code,
+                details={
+                    "request_id": result.request_id,
+                    "language_probability": result.language_probability,
+                },
+            )
+        except Exception as e:  # SDK/network/IO errors
             logger.exception("Sarvam transcription failed")
             return TranscriptionResponse(error=str(e))

--- a/src/echo/audio/transcription/sarvam.py
+++ b/src/echo/audio/transcription/sarvam.py
@@ -1,0 +1,124 @@
+"""Sarvam AI speech-to-text provider (on-prem default STT — plan decision #14).
+
+Uses Sarvam's Speech-to-Text API (saarika models) via httpx. Strong Indic
+language coverage. Configure with SARVAM_API_KEY; base URL overridable for
+proxies via config.base_url / SARVAM_BASE_URL.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+
+from .base import BaseTranscriber
+from .config import TranscriberConfig
+from .schemas import AudioInput, TranscriptionResponse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.sarvam.ai"
+DEFAULT_MODEL = "saarika:v2.5"
+
+# echo language codes → Sarvam language_code (BCP-47-ish)
+_LANGUAGE_MAP = {
+    "en": "en-IN",
+    "hi": "hi-IN",
+    "bn": "bn-IN",
+    "gu": "gu-IN",
+    "kn": "kn-IN",
+    "ml": "ml-IN",
+    "mr": "mr-IN",
+    "od": "od-IN",
+    "or": "od-IN",
+    "pa": "pa-IN",
+    "ta": "ta-IN",
+    "te": "te-IN",
+}
+
+_EXT_BY_MIME = {
+    "audio/mp4": "m4a",
+    "audio/m4a": "m4a",
+    "audio/mp3": "mp3",
+    "audio/mpeg": "mp3",
+    "audio/wav": "wav",
+    "audio/webm": "webm",
+    "audio/ogg": "ogg",
+}
+
+
+class SarvamTranscriber(BaseTranscriber):
+    """Transcriber backed by Sarvam's /speech-to-text endpoint."""
+
+    def __init__(self, config: TranscriberConfig):
+        super().__init__(config)
+        self.api_key = config.api_key or os.getenv("SARVAM_API_KEY")
+        self.base_url = (
+            getattr(config, "base_url", None)
+            or os.getenv("SARVAM_BASE_URL")
+            or DEFAULT_BASE_URL
+        ).rstrip("/")
+        if not self.api_key:
+            raise ValueError("Sarvam requires an API key (SARVAM_API_KEY)")
+
+    def _language_code(self) -> str:
+        lang = (self.config.language or "").strip()
+        if not lang:
+            return "unknown"  # Sarvam auto-detects
+        return _LANGUAGE_MAP.get(lang.lower(), lang)
+
+    async def transcribe(
+        self,
+        audio: AudioInput,
+        prompt: Optional[str] = None,
+        mime_type: Optional[str] = None,
+        **kwargs: Any,
+    ) -> TranscriptionResponse:
+        try:
+            if isinstance(audio, str):
+                if audio.startswith(("http://", "https://")):
+                    async with httpx.AsyncClient(timeout=60.0) as client:
+                        resp = await client.get(audio)
+                        resp.raise_for_status()
+                        content = resp.content
+                else:
+                    with open(audio, "rb") as f:
+                        content = f.read()
+            else:
+                content = audio
+
+            mime = mime_type or "audio/mp4"
+            ext = _EXT_BY_MIME.get(mime.split(";")[0].strip().lower(), "m4a")
+
+            data = {
+                "model": self.model or DEFAULT_MODEL,
+                "language_code": self._language_code(),
+            }
+            files = {"file": (f"audio.{ext}", content, mime)}
+
+            async with httpx.AsyncClient(
+                timeout=self.config.request_timeout_s
+            ) as client:
+                resp = await client.post(
+                    f"{self.base_url}/speech-to-text",
+                    headers={"api-subscription-key": self.api_key},
+                    data=data,
+                    files=files,
+                )
+
+            if resp.status_code != 200:
+                return TranscriptionResponse(
+                    error=f"Sarvam API {resp.status_code}: {resp.text[:500]}"
+                )
+
+            payload = resp.json()
+            return TranscriptionResponse(
+                text=payload.get("transcript", "") or "",
+                language_detected=payload.get("language_code"),
+                details={"request_id": payload.get("request_id")},
+            )
+        except Exception as e:  # network, IO
+            logger.exception("Sarvam transcription failed")
+            return TranscriptionResponse(error=str(e))

--- a/src/echo/llm/config.py
+++ b/src/echo/llm/config.py
@@ -76,8 +76,8 @@ class ThinkingConfig(BaseModel):
 class LLMConfig(BaseModel):
     """LLM provider configuration. Defaults to Bedrock Haiku."""
 
-    provider: Literal["bedrock", "openai", "anthropic", "gemini"] = os.getenv(
-        "ECHO_DEFAULT_LLM_PROVIDER", "bedrock"
+    provider: Literal["bedrock", "openai", "anthropic", "gemini", "openai_compatible"] = (
+        os.getenv("ECHO_DEFAULT_LLM_PROVIDER", "bedrock")
     )
     model: str = os.getenv(
         "ECHO_DEFAULT_LLM_MODEL", "anthropic.claude-3-haiku-20240307-v1:0"
@@ -90,6 +90,8 @@ class LLMConfig(BaseModel):
 
     # Optional user-provided API keys (falls back to env vars if None)
     api_key: Optional[str] = None  # For OpenAI, Anthropic, Gemini
+    # OpenAI-compatible endpoint (vLLM / Ollama / proxies); env: ECHO_LLM_BASE_URL
+    base_url: Optional[str] = None
     aws_access_key_id: Optional[str] = None  # For Bedrock
     aws_secret_access_key: Optional[str] = None  # For Bedrock
 

--- a/src/echo/llm/factory.py
+++ b/src/echo/llm/factory.py
@@ -86,8 +86,18 @@ def get_llm(config: LLMConfig) -> BaseLLM:
                 "Install with: pip install google-genai"
             )
 
+    elif provider == "openai_compatible":
+        try:
+            from .openai_compatible import OpenAICompatibleLLM
+
+            return OpenAICompatibleLLM(config)
+        except ImportError:
+            raise ImportError(
+                "openai is required for openai_compatible. Install with: pip install openai"
+            )
+
     else:
         raise ValueError(
             f"Unsupported LLM provider: {provider}. "
-            f"Supported providers: bedrock, openai, anthropic, gemini"
+            f"Supported providers: bedrock, openai, anthropic, gemini, openai_compatible"
         )

--- a/src/echo/llm/openai_compatible.py
+++ b/src/echo/llm/openai_compatible.py
@@ -1,0 +1,52 @@
+"""OpenAI-compatible LLM provider (plan decision #15).
+
+Points the OpenAI client at ANY OpenAI-compatible endpoint — vLLM or Ollama
+serving Qwen/MedGemma locally, LiteLLM proxies, or hosted services. Strips the
+OpenAI-only request parameters (max_completion_tokens heuristics,
+reasoning_effort) that open-model servers reject.
+
+Config: LLMConfig(provider="openai_compatible", base_url=..., model=...,
+api_key=...) with env fallbacks ECHO_LLM_BASE_URL / ECHO_LLM_API_KEY.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .config import LLMConfig
+from .openai import OpenAILLM
+
+
+class OpenAICompatibleLLM(OpenAILLM):
+    """OpenAI wire format against a configurable base_url."""
+
+    def __init__(self, config: LLMConfig):
+        super().__init__(config)
+        self.base_url = (
+            getattr(config, "base_url", None)
+            or os.getenv("ECHO_LLM_BASE_URL")
+            or "http://localhost:11434/v1"  # Ollama default
+        )
+
+    @property
+    def client(self):
+        if self._client is None:
+            from openai import OpenAI
+
+            api_key = (
+                self.config.api_key
+                or os.getenv("ECHO_LLM_API_KEY")
+                or "not-needed"  # local vLLM/Ollama don't check keys
+            )
+            self._client = OpenAI(api_key=api_key, base_url=self.base_url)
+        return self._client
+
+    # Open-model servers speak plain max_tokens and reject OpenAI-only params.
+    def _uses_max_completion_tokens(self) -> bool:
+        return False
+
+    def _supports_reasoning_effort(self) -> bool:
+        return False
+
+    def _is_reasoning_model(self) -> bool:
+        return False

--- a/src/echo/prompts/factory.py
+++ b/src/echo/prompts/factory.py
@@ -33,7 +33,12 @@ def get_prompt_provider(reset: bool = False) -> BasePromptProvider:
 
             _provider_instance = LangfusePromptProvider()
         else:
-            raise ValueError(f"Unsupported provider: {provider}")
+            if provider == "file":
+                from .file_provider import FilePromptProvider
+
+                _provider_instance = FilePromptProvider()
+            else:
+                raise ValueError(f"Unsupported provider: {provider}")
 
     return _provider_instance
 

--- a/src/echo/prompts/file_provider.py
+++ b/src/echo/prompts/file_provider.py
@@ -1,0 +1,124 @@
+"""File-based prompt provider (on-prem default — plan B2/B4).
+
+Resolution for prompt ``name`` under ``ECHO_PROMPT_DIR`` (default ./prompts),
+with ``/`` in names flattened to ``_`` (same convention as voice2rx's checked-in
+.md fallbacks, so one folder serves both):
+
+  1. {dir}/{flat}/{version}.yaml        — versioned layout; ``production`` file
+     in the folder names the default version (falls back to highest version)
+  2. {dir}/{flat}.yaml                  — flat YAML
+  3. {dir}/{flat}.md                    — plain markdown; whole file is the task
+
+YAML fields: ``prompt`` (required), ``role``/``goal``/``backstory`` (persona),
+``expected_output``, ``version``.
+
+Variable compilation reproduces Langfuse ``{{var}}`` semantics: ONLY ``{{key}}``
+placeholders are replaced; every other brace (JSON examples in prompt bodies)
+is left untouched. ``str.format`` would be wrong here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import yaml
+
+from echo.prompts.schemas import AgentPrompt, PromptPersona, PromptTask
+from echo.prompts.base import BasePromptProvider, FetchedPrompt, PromptFetchError
+
+
+def compile_langfuse_style(raw: str, variables: Optional[Dict[str, Any]] = None) -> str:
+    """Replace {{key}} placeholders only — literal braces survive."""
+    result = raw
+    for key, value in (variables or {}).items():
+        result = result.replace("{{" + str(key) + "}}", "" if value is None else str(value))
+    return result
+
+
+class FilePromptProvider(BasePromptProvider):
+    def __init__(self, prompt_dir: Optional[str] = None):
+        self.prompt_dir = Path(
+            prompt_dir or os.getenv("ECHO_PROMPT_DIR", "./prompts")
+        ).resolve()
+
+    def _flat(self, name: str) -> str:
+        return name.replace("/", "_")
+
+    def _resolve(self, name: str, version: Optional[str]) -> Tuple[Path, Optional[str]]:
+        flat = self._flat(name)
+        versioned_dir = self.prompt_dir / flat
+        if versioned_dir.is_dir():
+            if version:
+                path = versioned_dir / f"{version}.yaml"
+                if path.is_file():
+                    return path, version
+                raise PromptFetchError(f"Prompt '{name}' version {version} not found")
+            pointer = versioned_dir / "production"
+            if pointer.is_file():
+                v = pointer.read_text().strip()
+                path = versioned_dir / f"{v}.yaml"
+                if path.is_file():
+                    return path, v
+            versions = sorted(
+                (p for p in versioned_dir.glob("*.yaml")),
+                key=lambda p: (len(p.stem), p.stem),
+            )
+            if versions:
+                return versions[-1], versions[-1].stem
+            raise PromptFetchError(f"Prompt folder '{flat}/' has no versions")
+        flat_yaml = self.prompt_dir / f"{flat}.yaml"
+        if flat_yaml.is_file():
+            return flat_yaml, None
+        flat_md = self.prompt_dir / f"{flat}.md"
+        if flat_md.is_file():
+            return flat_md, None
+        raise PromptFetchError(
+            f"Prompt '{name}' not found under {self.prompt_dir} "
+            f"(tried {flat}/, {flat}.yaml, {flat}.md)"
+        )
+
+    async def get_prompt(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        prompt_variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> FetchedPrompt:
+        try:
+            path, resolved_version = self._resolve(name, version)
+            raw = path.read_text(encoding="utf-8")
+
+            if path.suffix == ".yaml":
+                data = yaml.safe_load(raw) or {}
+                body = data.get("prompt", "")
+                task_description = compile_langfuse_style(body, prompt_variables)
+                agent_prompt = AgentPrompt(
+                    persona=PromptPersona(
+                        role=data.get("role"),
+                        goal=data.get("goal"),
+                        backstory=data.get("backstory"),
+                    ),
+                    task=PromptTask(
+                        description=task_description,
+                        expected_output=data.get("expected_output"),
+                    ),
+                )
+                resolved_version = resolved_version or (
+                    str(data["version"]) if data.get("version") else None
+                )
+            else:  # .md — whole file is the task description
+                task_description = compile_langfuse_style(raw, prompt_variables)
+                agent_prompt = AgentPrompt(
+                    persona=PromptPersona(),
+                    task=PromptTask(description=task_description),
+                )
+
+            return FetchedPrompt(
+                name=name, version=resolved_version, agent_prompt=agent_prompt
+            )
+        except PromptFetchError:
+            raise
+        except Exception as e:
+            raise PromptFetchError(f"Failed to fetch '{name}': {e}")

--- a/tests/test_onprem_providers.py
+++ b/tests/test_onprem_providers.py
@@ -22,8 +22,17 @@ def test_sarvam_provider_registered(monkeypatch):
     config = TranscriberConfig(provider="sarvam", language="hi")
     assert config.model == "saarika:v2.5"
     t = get_transcriber(config)
-    assert t.base_url == "https://api.sarvam.ai"
+    assert t.base_url is None  # SDK default endpoint
     assert t._language_code() == "hi-IN"
+
+
+def test_sarvam_base_url_override(monkeypatch):
+    monkeypatch.setenv("SARVAM_API_KEY", "test-key")
+    from echo.audio.transcription.config import TranscriberConfig
+    from echo.audio.transcription.factory import get_transcriber
+
+    t = get_transcriber(TranscriberConfig(provider="sarvam", base_url="https://proxy.local"))
+    assert t.client._client_wrapper.get_environment().base == "https://proxy.local"
 
 
 def test_openai_compatible_llm(monkeypatch):

--- a/tests/test_onprem_providers.py
+++ b/tests/test_onprem_providers.py
@@ -1,0 +1,90 @@
+"""Tests for the on-prem provider additions (sarvam, openai_compatible, file prompts)."""
+
+import asyncio
+
+import pytest
+
+
+def test_backcompat_aliases():
+    from echo import AgentConfig, PersonaConfig, TaskConfig
+    from echo.prompts.schemas import AgentPrompt, PromptPersona, PromptTask
+
+    assert AgentConfig is AgentPrompt
+    assert PersonaConfig is PromptPersona
+    assert TaskConfig is PromptTask
+
+
+def test_sarvam_provider_registered(monkeypatch):
+    monkeypatch.setenv("SARVAM_API_KEY", "test-key")
+    from echo.audio.transcription.config import TranscriberConfig
+    from echo.audio.transcription.factory import get_transcriber
+
+    config = TranscriberConfig(provider="sarvam", language="hi")
+    assert config.model == "saarika:v2.5"
+    t = get_transcriber(config)
+    assert t.base_url == "https://api.sarvam.ai"
+    assert t._language_code() == "hi-IN"
+
+
+def test_openai_compatible_llm(monkeypatch):
+    monkeypatch.delenv("ECHO_LLM_BASE_URL", raising=False)
+    from echo.llm import LLMConfig, get_llm
+
+    llm = get_llm(
+        LLMConfig(
+            provider="openai_compatible",
+            model="qwen3:14b",
+            base_url="http://vllm.local:8000/v1",
+        )
+    )
+    assert llm.base_url == "http://vllm.local:8000/v1"
+    assert llm._uses_max_completion_tokens() is False
+    assert llm._supports_reasoning_effort() is False
+
+
+def test_file_prompt_provider_langfuse_semantics(tmp_path):
+    (tmp_path / "my_agent.md").write_text(
+        'You are {{role_name}}. Output JSON like {"a": 1, "b": {{count}}}.'
+    )
+    from echo.prompts.file_provider import FilePromptProvider
+
+    provider = FilePromptProvider(prompt_dir=str(tmp_path))
+    fetched = asyncio.run(
+        provider.get_prompt("my_agent", prompt_variables={"role_name": "a scribe", "count": 3})
+    )
+    desc = fetched.agent_prompt.task.description
+    assert "You are a scribe." in desc
+    assert '{"a": 1, "b": 3}' in desc  # literal braces survive
+
+
+def test_file_prompt_provider_versions(tmp_path):
+    d = tmp_path / "team_summary_agent"
+    d.mkdir()
+    (d / "1.yaml").write_text("prompt: v1 body\n")
+    (d / "2.yaml").write_text("prompt: v2 body\nrole: summarizer\n")
+    (d / "production").write_text("2\n")
+    from echo.prompts.file_provider import FilePromptProvider
+
+    provider = FilePromptProvider(prompt_dir=str(tmp_path))
+    fetched = asyncio.run(provider.get_prompt("team/summary/agent"))
+    assert fetched.version == "2"
+    assert fetched.agent_prompt.persona.role == "summarizer"
+
+
+def test_file_prompt_provider_missing(tmp_path):
+    from echo.prompts.base import PromptFetchError
+    from echo.prompts.file_provider import FilePromptProvider
+
+    with pytest.raises(PromptFetchError):
+        asyncio.run(FilePromptProvider(prompt_dir=str(tmp_path)).get_prompt("nope"))
+
+
+def test_prompt_factory_file_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("ECHO_PROMPT_PROVIDER", "file")
+    monkeypatch.setenv("ECHO_PROMPT_DIR", str(tmp_path))
+    from echo.prompts.factory import get_prompt_provider, reset_prompt_provider
+    from echo.prompts.file_provider import FilePromptProvider
+
+    reset_prompt_provider()
+    assert isinstance(get_prompt_provider(), FilePromptProvider)
+    reset_prompt_provider()

--- a/uv.lock
+++ b/uv.lock
@@ -900,7 +900,7 @@ postgres = [
     { name = "asyncpg" },
 ]
 sarvam = [
-    { name = "httpx" },
+    { name = "sarvamai" },
 ]
 
 [package.metadata]
@@ -917,7 +917,6 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0.0" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'ekacare'", specifier = ">=0.27.0" },
-    { name = "httpx", marker = "extra == 'sarvam'", specifier = ">=0.27.0" },
     { name = "jsonpatch", marker = "extra == 'ag-ui'", specifier = ">=1.33" },
     { name = "langfuse", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.0.0" },
@@ -932,6 +931,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sarvamai", marker = "extra == 'sarvam'", specifier = ">=0.1.20" },
 ]
 provides-extras = ["bedrock", "openai", "anthropic", "gemini", "ekacare", "sarvam", "crewai", "mcp", "postgres", "langfuse", "ag-ui", "all", "dev"]
 
@@ -3413,6 +3413,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "sarvamai"
+version = "0.1.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/44/57a7a37be64953bb0bec9f674e92a9f8fb7070ce6aeb44c6f22720458b40/sarvamai-0.1.28.tar.gz", hash = "sha256:bc52f0c849e429d1a4493e49b1b4b65bf06965f3936d4eb6ee3da3130452e7ea", size = 139022, upload-time = "2026-04-20T08:05:12.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/90/95cd195a3a2ae9a9973c6a05705207e8dd97b5aea90339bc24343cb54850/sarvamai-0.1.28-py3-none-any.whl", hash = "sha256:52e71c0a0f521552d4d948ec452699b44554a56e64ee354b14da2efc9d9046b3", size = 269335, upload-time = "2026-04-20T08:05:10.712Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "echo"
-version = "0.3.6"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },
@@ -899,6 +899,9 @@ openai = [
 postgres = [
     { name = "asyncpg" },
 ]
+sarvam = [
+    { name = "httpx" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -914,6 +917,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0.0" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'ekacare'", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'sarvam'", specifier = ">=0.27.0" },
     { name = "jsonpatch", marker = "extra == 'ag-ui'", specifier = ">=1.33" },
     { name = "langfuse", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.0.0" },
@@ -929,7 +933,7 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["bedrock", "openai", "anthropic", "gemini", "ekacare", "crewai", "mcp", "postgres", "langfuse", "ag-ui", "all", "dev"]
+provides-extras = ["bedrock", "openai", "anthropic", "gemini", "ekacare", "sarvam", "crewai", "mcp", "postgres", "langfuse", "ag-ui", "all", "dev"]
 
 [[package]]
 name = "et-xmlfile"


### PR DESCRIPTION
…mpt provider

- SarvamTranscriber (saarika:v2.5, Indic language map, base_url override); TranscriberConfig gains base_url + sarvam provider
- OpenAICompatibleLLM: any OpenAI-compatible base_url (vLLM/Ollama/proxies), strips OpenAI-only request params; LLMConfig gains base_url + provider
- FilePromptProvider: file-based prompts with Langfuse {{var}} semantics (literal braces survive), flat .md/.yaml + versioned folder layouts; ECHO_PROMPT_PROVIDER=file
- back-compat aliases: AgentConfig/PersonaConfig/TaskConfig -> AgentPrompt/PromptPersona/PromptTask (pre-0.3.7 consumers upgrade without changes)
- version 0.4.0; tests included